### PR TITLE
ci: install dependabot for github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+# ref: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
actions are throwing deprecation warnings: https://github.com/BalancerMaxis/arbitrum_grants_distributor/actions/runs/9912788245

this will auto pr bumps to gh actions where needed