### PR TITLE
Update config for this stip round

### DIFF
--- a/automation/arbitrum_stip_bridge_start_q2_2024.py
+++ b/automation/arbitrum_stip_bridge_start_q2_2024.py
@@ -43,7 +43,7 @@ ACTIVE_POOLS_AND_OVERRIDES = [
         "pool_id": "0x59743f1812bb85db83e9e4ee061d124aaa64290000000000000000000000052b",
         "meta": {"symbol": "sUSDe-sFRAX"},
         "fixedBoost": 1.5,
-        "fixedEmissions": 8_000,
+        "fixedEmissions": 4_000,
     },
     {
         "pool_id": "0x2f0cdf8596be980ef24924ca7bf54e630ca526b2000000000000000000000529",


### PR DESCRIPTION
No new pools.  Reduce fixed on sUSDe/sFRAX to 50% of last time, with no fixed for next round.